### PR TITLE
Add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .hgignore
 .hg/
 doc/api
+test/debug.log

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [net.n01se/clojure-jna "1.0.0"]
                  [robert/hooke "1.3.0"]]
-  :profiles {:dev {:plugins [[lein-codox "0.9.1"]]}}
+  :profiles {:dev {:plugins [[lein-codox "0.9.1"]]}
+             :test {:jvm-opts ["-Djava.util.logging.config.file=test/logging.properties"]}}
   :deploy-repositories ^:replace [["clojars" {:url "https://clojars.org/repo"
                                               :username [:gpg :env/clojars_username]
                                               :password [:gpg :env/clojars_password]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,9 @@
   :pedantic? :abort
   :java-source-paths ["src-java"]
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [net.n01se/clojure-jna "1.0.0"]]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [net.n01se/clojure-jna "1.0.0"]
+                 [robert/hooke "1.3.0"]]
   :profiles {:dev {:plugins [[lein-codox "0.9.1"]]}}
   :deploy-repositories ^:replace [["clojars" {:url "https://clojars.org/repo"
                                               :username [:gpg :env/clojars_username]

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :java-source-paths ["src-java"]
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [digest "1.4.4"]
                  [net.n01se/clojure-jna "1.0.0"]
                  [robert/hooke "1.3.0"]]
   :profiles {:dev {:plugins [[lein-codox "0.9.1"]]}

--- a/release.sh
+++ b/release.sh
@@ -80,6 +80,8 @@ build_jars() {
 
 save_artifacts() {
   if [ -n "${CIRCLE_ARTIFACTS:-}" ]; then
+    echo "Saving debug log..."
+    cp test/debug.log "${CIRCLE_ARTIFACTS}"
     echo "Copying JARs to CircleCI artifacts..."
     find . -name '*.jar' -exec cp {} "${CIRCLE_ARTIFACTS}" \;
   fi

--- a/src/clj_libssh2/logging.clj
+++ b/src/clj_libssh2/logging.clj
@@ -1,0 +1,80 @@
+(ns clj-libssh2.logging
+  "Functions for weaving some detailed debug logging into every function in
+   clj-libssh2."
+  (:require [clojure.tools.logging :as log]
+            [clojure.pprint :refer [pprint]]
+            [robert.hooke :as hook]))
+
+(defn- spy-fn
+  "Create a function that can be used as a hook to log the call and result from
+   a given function. This is somewhat similar to the log/spy macro in
+   clojure.tools.logging but that doesn't work too neatly with robert.hooke.
+
+   Arguments:
+
+   fn-var A var pointing to the function we'll be tracing.
+   level  The level at which the messages should be logged.
+
+   Return:
+
+   A function of the form `(fn [f & args])` which can be given to
+   robert.hooke/add-hook to hook a function."
+  [fn-var level]
+  (let [fn-meta (meta fn-var)
+        fn-name (symbol (str (ns-name (:ns fn-meta))) (str (:name fn-meta)))
+        make-message (fn [args result]
+                       (format "%s => %s"
+                               (with-out-str (pprint (cons fn-name args)))
+                               (with-out-str (pprint result))))]
+    (fn [f & args]
+      (try
+        (let [result (apply f args)]
+          (log/log level (make-message args result))
+          result)
+        (catch Throwable t
+          (log/log level t (make-message args t))
+          (throw t))))))
+
+(defn trace-fn
+  "Hook a function so that all calls to it (and the results of those calls) are
+   logged at a given level.
+
+   Arguments:
+
+   fn-var A var pointing to the function to trace.
+   level  The log level at which the function call and result should be logged.
+
+   Return:
+
+   See robert.hooke/add-hook for the description of the return value."
+  [fn-var level]
+  (hook/add-hook fn-var (spy-fn fn-var level)))
+
+(defn trace-ns
+  "Apply (trace-fn % level) to all functions in a given namespace.
+
+   Arguments:
+
+   ns-sym The symbolic name of a namespace.
+   level  The level to log all calls at.
+
+   Return:
+
+   nil"
+  [ns-sym level]
+  (doseq [fn-var (filter #(fn? (var-get %)) (vals (ns-interns ns-sym)))]
+    (trace-fn fn-var level)))
+
+(defn- init*
+  "Initialise the logging of clj-libssh2 by applying trace-ns to all of the
+   namespaces in the library if debug logging is enabled."
+  []
+  (doseq [nmspc (all-ns)]
+    (when (and (not (= 'clj-libssh2.logging (ns-name nmspc)))
+               (re-find #"^clj-libssh2\." (str (ns-name nmspc))))
+      (trace-ns nmspc :trace))))
+
+(def ^{:arglists '([])} init
+  "Initialise the logging of clj-libssh2 by applying trace-ns to all of the
+   namespaces in the library if debug logging is enabled."
+  (memoize init*))

--- a/src/clj_libssh2/socket.clj
+++ b/src/clj_libssh2/socket.clj
@@ -1,6 +1,7 @@
 (ns clj-libssh2.socket
-  (:require [net.n01se.clojure-jna :as jna]
-            [clj-libssh2.error :refer [handle-errors]]
+  (:require [clojure.tools.logging :as log]
+            [net.n01se.clojure-jna :as jna]
+            [clj-libssh2.error :as error :refer [handle-errors]]
             [clj-libssh2.libssh2 :as libssh2]
             [clj-libssh2.libssh2.keepalive :as libssh2-keepalive]
             [clj-libssh2.libssh2.session :as libssh2-session])
@@ -40,12 +41,13 @@
                       (format "Failed to connect to %s:%d" address port)
 
                       "simple_socket_connect returned a bad value")]
-        (throw (ex-info message {:socket socket}))))
+        (error/raise message {:socket socket})))
     socket))
 
 (defn select
   "Call select on a socket from a clj-libssh2 Session."
   [session select-read select-write timeout]
+  (log/debug "Calling select() on the socket.")
   (jna/invoke Integer
               simplesocket/simple_socket_select
               (:socket session)
@@ -58,6 +60,7 @@
   "Send a keepalive message and return the number of seconds until the next
    time we should send a keepalive."
   [session]
+  (log/debug "Sending a keepalive.")
   (let [seconds-to-wait (IntByReference.)]
     (handle-errors session
       (libssh2-keepalive/send (:session session) seconds-to-wait))

--- a/test/clj_libssh2/test_ssh.clj
+++ b/test/clj_libssh2/test_ssh.clj
@@ -60,7 +60,7 @@
           (is (= 0 (:exit result)))))
       (testing "Commands can be given a lot of input on STDIN"
         (let [input-line (str (str/join "" (repeat 1024 "x")) "\n")
-              input (str/join "" (repeat (* 10 1024) input-line))
+              input (str/join "" (repeat 1024 input-line))
               result (ssh/exec session timeout-cat :in input)]
           (is (= (count input) (count (:out result))))
           (is (= "" (:err result)))

--- a/test/clj_libssh2/test_utils.clj
+++ b/test/clj_libssh2/test_utils.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.shell :as sh]
             [clojure.string :as str]
             [clojure.test :as test]
-            [net.n01se.clojure-jna :as jna]))
+            [net.n01se.clojure-jna :as jna]
+            [clj-libssh2.logging :as logging]))
 
 (def ssh-host "127.0.0.1")
 (def ssh-port 2222)
@@ -50,6 +51,13 @@
   (f)
   (teardown))
 
+(defn with-really-verbose-logging
+  [f]
+  (logging/init)
+  (f))
+
 (defn fixtures
   []
-  (test/use-fixtures :once with-sandbox-sshd))
+  (test/use-fixtures :once (test/join-fixtures
+                             [with-sandbox-sshd
+                              with-really-verbose-logging])))

--- a/test/logging.properties
+++ b/test/logging.properties
@@ -1,0 +1,8 @@
+handlers=java.util.logging.FileHandler
+.level=ALL
+
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT %1$tz] %4$s: %5$s%6$s%n
+
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.level=ALL
+java.util.logging.FileHandler.pattern=test/debug.log


### PR DESCRIPTION
- Add some progress logging so that consumers of the library can track its progress.
- Trace all inputs and outputs to all functions called from tests.
